### PR TITLE
Set attack-boost radius to 5 under "move" and "stop" skill

### DIFF
--- a/techs/zetapack/factions/tech/units/technician/technician.xml
+++ b/techs/zetapack/factions/tech/units/technician/technician.xml
@@ -75,7 +75,7 @@
 			<sound enabled="false"/>
 			<attack-boost>
 				<allow-multiple-boosts value="true" />
-				<radius value="15"/>
+				<radius value="5"/>
 				<target value="faction">
 					<unit-type name="archer" />
 					<unit-type name="guard" />
@@ -104,7 +104,7 @@
 			<sound enabled="false"/>
 			<attack-boost>
 				<allow-multiple-boosts value="true" />
-				<radius value="15"/>
+				<radius value="5"/>
 				<target value="faction">
 					<unit-type name="archer" />
 					<unit-type name="guard" />


### PR DESCRIPTION
Reduced the attack-boost radius from 15 to 5 for technician under the "move" and "stop" skill.
fixes #231